### PR TITLE
Remove HASH_KEY & ensure test messages are >16 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bls [![Crates.io](https://img.shields.io/crates/v/bls.svg)](https://crates.io/crates/bls) #
+**This is an experimental library and is NOT SAFE**
 
 This is a Rust crate for making BLS (Boneh-Lynn-Shacham) signatures. It currently supports the [BLS12-381](https://z.cash/blog/new-snark-curve.html) (Barreto-Lynn-Scott) (yes, I know) construction.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,15 +110,18 @@ impl<E: Engine> AggregateSignature<E> {
         lhs == rhs
     }
 
+    /// Verify a aggregate signatures over a common message.
+    ///
+    /// Warning: This method is vulnerable to the "rouge public-key attack".
+    /// Every user must be required to prove knowledge or possession of their
+    /// corresponding secret key. For more information, see: 
+    /// https://eprint.iacr.org/2018/483.pdf
     pub fn verify_common_message(
         &self,
         message: &[u8],
         pubkeys: &Vec<&PublicKey<E>>)
         -> bool
     {
-        // Messages must be identical
-        // Be warned of the rouge key attack:
-        // https://rist.tech.cornell.edu/papers/pkreg.pdf
         let h = E::G1Affine::hash(message);
         // Check pairings
         let lhs = E::pairing(self.0.s, E::G2Affine::one());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use pairing::{CurveAffine, CurveProjective, Engine, Field};
 use rand::{Rand, Rng};
 use std::collections::HashSet;
 
+#[derive(Debug, PartialEq)]
 pub struct Signature<E: Engine> {
     s: E::G1,
 }
@@ -75,6 +76,7 @@ impl<E: Engine> Keypair<E> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AggregateSignature<E: Engine>(Signature<E>);
 
 impl<E: Engine> AggregateSignature<E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ mod tests {
 
         for i in 0..500 {
             let keypair = Keypair::<Bls12>::generate(&mut rng);
-            let message = format!("Message {}", i);
+            let message = format!(">16 character message {}", i);
             let sig = keypair.sign(&message.as_bytes());
             assert_eq!(keypair.verify(&message.as_bytes(), &sig), true);
         }
@@ -130,7 +130,7 @@ mod tests {
         let mut signatures = Vec::with_capacity(1000);
         for i in 0..500 {
             let keypair = Keypair::<Bls12>::generate(&mut rng);
-            let message = format!("Message {}", i);
+            let message = format!(">16 character message {}", i);
             let signature = keypair.sign(&message.as_bytes());
             inputs.push((keypair.public, message));
             signatures.push(signature);
@@ -158,7 +158,7 @@ mod tests {
 
         // Create the first signature
         let keypair = Keypair::<Bls12>::generate(&mut rng);
-        let message = "First message";
+        let message = ">16 char first message";
         let signature = keypair.sign(&message.as_bytes());
         inputs.push((keypair.public, message));
         asig.aggregate(&signature);
@@ -174,7 +174,7 @@ mod tests {
 
         // Create the second signature
         let keypair = Keypair::<Bls12>::generate(&mut rng);
-        let message = "Second message";
+        let message = ">16 char second message";
         let signature = keypair.sign(&message.as_bytes());
         inputs.push((keypair.public, message));
         asig.aggregate(&signature);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,14 @@ pub struct PublicKey<E: Engine> {
     p_pub: E::G2,
 }
 
+impl<E: Engine> Clone for PublicKey<E> {
+    fn clone(&self) -> Self {
+        Self {
+            p_pub: self.p_pub.clone()
+        }
+    }
+}
+
 impl<E: Engine> PublicKey<E> {
     pub fn from_secret(secret: &SecretKey<E>) -> Self {
         // TODO Decide on projective vs affine
@@ -119,6 +127,19 @@ mod tests {
             let message = format!(">16 character message {}", i);
             let sig = keypair.sign(&message.as_bytes());
             assert_eq!(keypair.verify(&message.as_bytes(), &sig), true);
+        }
+    }
+
+    #[test]
+    fn sign_verify_with_cloned_public() {
+        let mut rng = XorShiftRng::from_seed([0xbc4f6d44, 0xd62f276c, 0xb963afd0, 0x5455863d]);
+
+        for i in 0..500 {
+            let keypair = Keypair::<Bls12>::generate(&mut rng);
+            let message = format!(">16 character message {}", i);
+            let sig = keypair.sign(&message.as_bytes());
+            let cloned_pub = keypair.public.clone();
+            assert_eq!(cloned_pub.verify(&message.as_bytes(), &sig), true);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,32 +163,48 @@ mod tests {
     }
 
     #[test]
-    fn sign_verify_aggregate_common_message() {
+    fn test_sign_verify_aggregate_common_message_short() {
+        sign_verify_aggregate_common_message(10);
+    }
+    #[test]
+    #[ignore]
+    fn test_sign_verify_aggregate_common_message_long() {
+        sign_verify_aggregate_common_message(500);
+    }
+    fn sign_verify_aggregate_common_message(loop_count: u32) {
         let mut rng = XorShiftRng::from_seed([0xbc4f6d44, 0xd62f276c, 0xb963afd0, 0x5455863d]);
 
-        let loop_count = 10;
         let mut pubkeys = Vec::with_capacity(1000);
         let mut signatures = Vec::with_capacity(1000);
         let message = ">16 character indentical message".as_bytes();
-        for _ in 0..loop_count {
+        for i in 0..loop_count {
             let keypair = Keypair::<Bls12>::generate(&mut rng);
             let signature = keypair.sign(&message);
             pubkeys.push(keypair.public);
             signatures.push(signature);
 
-            let asig = AggregateSignature::from_signatures(&signatures);
-            assert_eq!(
-                asig.verify_common_message(&message, &pubkeys.iter().map(|&ref pk| pk).collect()),
-                true
-            );
+            if i < 10 || i > (loop_count - 5) {
+                let asig = AggregateSignature::from_signatures(&signatures);
+                assert_eq!(
+                    asig.verify_common_message(&message, &pubkeys.iter().map(|&ref pk| pk).collect()),
+                    true
+                );
+            }
         }
     }
 
     #[test]
-    fn sign_verify_aggregate_common_message_missing_sig() {
+    fn test_sign_verify_aggregate_common_message_missing_sig_short() {
+        sign_verify_aggregate_common_message_missing_sig(10);
+    }
+    #[test]
+    #[ignore]
+    fn test_sign_verify_aggregate_common_message_missing_sig_long() {
+        sign_verify_aggregate_common_message_missing_sig(500);
+    }
+    fn sign_verify_aggregate_common_message_missing_sig(loop_count: u32) {
         let mut rng = XorShiftRng::from_seed([0xbc4f6d44, 0xd62f276c, 0xb963afd0, 0x5455863d]);
 
-        let loop_count = 10;
         let skipped_sig = loop_count / 2;
         let mut pubkeys = Vec::with_capacity(1000);
         let mut signatures = Vec::with_capacity(1000);
@@ -201,11 +217,13 @@ mod tests {
                 signatures.push(signature);
             }
 
-            let asig = AggregateSignature::from_signatures(&signatures);
-            assert_eq!(
-                asig.verify_common_message(&message, &pubkeys.iter().map(|&ref pk| pk).collect()),
-                i < skipped_sig
-            );
+            if i < 10 || i > (loop_count - 5) {
+                let asig = AggregateSignature::from_signatures(&signatures);
+                assert_eq!(
+                    asig.verify_common_message(&message, &pubkeys.iter().map(|&ref pk| pk).collect()),
+                    i < skipped_sig
+                );
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@ use pairing::{CurveAffine, CurveProjective, Engine, Field};
 use rand::{Rand, Rng};
 use std::collections::HashSet;
 
-const HASH_KEY: &[u8] = b"BLSSignatureSeed";
-
 pub struct Signature<E: Engine> {
     s: E::G1,
 }
@@ -23,7 +21,7 @@ impl<E: Engine> SecretKey<E> {
     }
 
     pub fn sign(&self, message: &[u8]) -> Signature<E> {
-        let h = E::G1Affine::hash(HASH_KEY, message);
+        let h = E::G1Affine::hash(message);
         Signature { s: h.mul(self.x) }
     }
 }
@@ -41,7 +39,7 @@ impl<E: Engine> PublicKey<E> {
     }
 
     pub fn verify(&self, message: &[u8], signature: &Signature<E>) -> bool {
-        let h = E::G1Affine::hash(HASH_KEY, message);
+        let h = E::G1Affine::hash(message);
         let lhs = E::pairing(signature.s, E::G2Affine::one());
         let rhs = E::pairing(h, self.p_pub);
         lhs == rhs
@@ -98,7 +96,7 @@ impl<E: Engine> AggregateSignature<E> {
         let lhs = E::pairing(self.0.s, E::G2Affine::one());
         let mut rhs = E::Fqk::one();
         for input in inputs {
-            let h = E::G1Affine::hash(HASH_KEY, input.1);
+            let h = E::G1Affine::hash(input.1);
             rhs.mul_assign(&E::pairing(h, input.0.p_pub));
         }
         lhs == rhs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,10 +143,18 @@ mod tests {
     use rand::{SeedableRng, XorShiftRng};
 
     #[test]
-    fn sign_verify() {
+    fn test_sign_verify_short() {
+        sign_verify(10);
+    }
+    #[test]
+    #[ignore]
+    fn test_sign_verify_long() {
+        sign_verify(500);
+    }
+    fn sign_verify(loop_count: u32) {
         let mut rng = XorShiftRng::from_seed([0xbc4f6d44, 0xd62f276c, 0xb963afd0, 0x5455863d]);
 
-        for i in 0..500 {
+        for i in 0..loop_count {
             let keypair = Keypair::<Bls12>::generate(&mut rng);
             let message = format!(">16 character message {}", i);
             let sig = keypair.sign(&message.as_bytes());
@@ -155,10 +163,18 @@ mod tests {
     }
 
     #[test]
-    fn sign_verify_with_cloned_public() {
+    fn test_sign_verify_with_clone_pubic_short() {
+        sign_verify_with_cloned_public(10);
+    }
+    #[test]
+    #[ignore]
+    fn test_sign_verify_with_clone_pubic_long() {
+        sign_verify_with_cloned_public(500);
+    }
+    fn sign_verify_with_cloned_public(loop_count: u32) {
         let mut rng = XorShiftRng::from_seed([0xbc4f6d44, 0xd62f276c, 0xb963afd0, 0x5455863d]);
 
-        for i in 0..500 {
+        for i in 0..loop_count {
             let keypair = Keypair::<Bls12>::generate(&mut rng);
             let message = format!(">16 character message {}", i);
             let sig = keypair.sign(&message.as_bytes());
@@ -233,12 +249,20 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_signatures() {
+    fn aggregate_signatures_short() {
+        aggregate_signatures(20);
+    }
+    #[test]
+    #[ignore]
+    fn aggregate_signatures_long() {
+        aggregate_signatures(500);
+    }
+    fn aggregate_signatures(loop_count: u32) {
         let mut rng = XorShiftRng::from_seed([0xbc4f6d44, 0xd62f276c, 0xb963afd0, 0x5455863d]);
 
         let mut inputs = Vec::with_capacity(1000);
         let mut signatures = Vec::with_capacity(1000);
-        for i in 0..500 {
+        for i in 0..loop_count {
             let keypair = Keypair::<Bls12>::generate(&mut rng);
             let message = format!(">16 character message {}", i);
             let signature = keypair.sign(&message.as_bytes());
@@ -246,7 +270,7 @@ mod tests {
             signatures.push(signature);
 
             // Only test near the beginning and the end, to reduce test runtime
-            if i < 10 || i > 495 {
+            if i < 10 || i > (loop_count - 5) {
                 let asig = AggregateSignature::from_signatures(&signatures);
                 assert_eq!(
                     asig.verify(&inputs


### PR DESCRIPTION
When attempting to import this crate I found that it failed to build and then failed to pass the tests. I have made two changes to address those issues respectively:

1. Remove the `HASH_KEY` const as it is not permitted for the `G1Affine::hash` function. I tried to find if/when/why the `HASH_KEY` param was removed from [pairing](https://github.com/mmaker/pairing), but I didn't find anything in a cursory search.
2. Ensure that all messages used in tests are >16 chars long. This is a [requirement](https://github.com/mmaker/pairing/blob/69fe215da1523ff841bdd31e7033768c63f5ccd5/src/bls12_381/ec.rs#L263) of [pairing](https://github.com/mmaker/pairing).

Please note that I'm not a cryptographer and I figure these changes "seem harmless enough". Merge with caution.

Thanks for making this repo!